### PR TITLE
Allow for non-0 min value in slider.py

### DIFF
--- a/pygame_widgets/slider.py
+++ b/pygame_widgets/slider.py
@@ -55,10 +55,10 @@ class Slider(WidgetBase):
 
             if self.selected:
                 if self.vertical:
-                    self.value = self.max - self.round((y - self._y) / self._height * self.max)
+                    self.value = self.max - self.round((y - self._y) / self._height * (self.max - self.min))
                     self.value = max(min(self.value, self.max), self.min)
                 else:
-                    self.value = self.round((x - self._x) / self._width * self.max + self.min)
+                    self.value = self.round((x - self._x) / self._width * (self.max - self.min) + self.min)
                     self.value = max(min(self.value, self.max), self.min)
 
     def draw(self):


### PR DESCRIPTION
We ran into an issue with:

```py
Slider(screen, 600, 80, 100, 10, min=0.7, max=1, step=0.005)
```

where dragging the slider caused the value to grow too large too quickly. Changing the amount the value is scaled by to `self.max - self.min` fixes that issue.