### PR TITLE
Update slider index.html

### DIFF
--- a/site/slider/index.html
+++ b/site/slider/index.html
@@ -146,7 +146,7 @@ while run:
     slider.listen(events)
     slider.draw()
 
-    output.setText(slider.getValue())
+    output.setText(str(slider.getValue()))
 
     output.draw()
 


### PR DESCRIPTION
Tiny change to the slider example usage. TextBox takes str, and does not auto-convert the int from the slider to a str. This makes the example runable,.