### PR TITLE
Update slider index.html

### DIFF
--- a/site/slider/index.html
+++ b/site/slider/index.html
@@ -130,7 +130,7 @@ pygame.init()
 win = pygame.display.set_mode((1000, 600))
 
 slider = Slider(win, 100, 100, 800, 40, min=0, max=99, step=1)
-output = TextBox(win, 475, 200, 50, 50, fontSize=30)
+output = TextBox(win, 475, 200, 60, 50, fontSize=30)
 
 run = True
 while run:
@@ -146,7 +146,7 @@ while run:
     slider.listen(events)
     slider.draw()
 
-    output.setText(slider.getValue())
+    output.setText(str(slider.getValue()))
 
     output.draw()
 


### PR DESCRIPTION
Tiny change to the slider example usage. TextBox takes str, and does not auto-convert the int from the slider to a str. This makes the example runnable.

In addition, I've widened the textbox, so it shows both digits of the slider's value. I am unsure if this is a platform/device specific behavior, but on my machine only the second digit of the value was shown, making the example somewhat confusing.