### PR TITLE
Fix: Convert text to string in text.replace() to prevent Type/Attribu…

### DIFF
--- a/pygame_widgets/textbox.py
+++ b/pygame_widgets/textbox.py
@@ -704,7 +704,7 @@ class TextBox(WidgetBase):
         Args:
             text (str): The text to add to the text box
         """
-        text = list(text.replace('\t', ' ' * self.tabSpaces))
+        text = list(str(text).replace('\t', ' ' * self.tabSpaces))
 
         for char in text:
             if not char or self.isSpecialChar(char) and char != '\n':


### PR DESCRIPTION
Fix: Convert text to string in text.replace() to prevent Type/AttributeError

This is my first pull request, don't blame me if I described the problem not properly.

When I cloned the repo and tested the slider.py file with `python -m pygame_widgets.slider` I got this error:

> Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\...\PygameWidgets\pygame_widgets\slider.py", line 153, in <module>
    output.setText(slider.getValue())
  File "C:\...\PygameWidgets\pygame_widgets\textbox.py", line 823, in setText
    self.addText(text)
  File "C:\...\PygameWidgets\pygame_widgets\textbox.py", line 707, in addText
    text = list(text.replace('\t', ' ' * self.tabSpaces))
                ^^^^^^^^^^^^
AttributeError: 'int' object has no attribute 'replace'

Then I saw that in the pygame_widgets/textbox.py file line 707, the `text = list(text.replace('\t', ' ' * self.tabSpaces))` code gets a float value instead of a string. Because int objects don't have .replace() method it raises error. Why this happened? Because slider.getValue() returns a float/int value while passing it into TextBox.setText().
And I simply added a type convertion on the textbox.py line 707.

I hope this helps.